### PR TITLE
OUR 35: [API] All Events VIEW - Controller Method && Mode Validation

### DIFF
--- a/apps/api/app/controllers/events_controller.rb
+++ b/apps/api/app/controllers/events_controller.rb
@@ -13,9 +13,7 @@ class EventsController < ApplicationController
   # GET /events/upcoming
   def upcoming
     today = Time.now.beginning_of_day
-    future_date = today + 2.years
-    range = today..future_date
-    @events = Event.where(start: range)
+    @events = Event.where("start >= ?", today)
   
     render json: @events, include: [:user]
   end

--- a/apps/api/app/controllers/events_controller.rb
+++ b/apps/api/app/controllers/events_controller.rb
@@ -1,3 +1,5 @@
+require "time"
+
 class EventsController < ApplicationController
   before_action :set_event, only: %i[show update destroy]
 
@@ -11,6 +13,14 @@ class EventsController < ApplicationController
   # GET /events/1
   def show
     render json: @event
+  end
+
+    # GET /events/upcoming
+  def upcoming
+    today = Time.today.beginning_of_day
+    @events = Event.where('start > ?', today)
+  
+    render json: @events
   end
 
   # POST /events

--- a/apps/api/app/controllers/events_controller.rb
+++ b/apps/api/app/controllers/events_controller.rb
@@ -10,17 +10,19 @@ class EventsController < ApplicationController
     render json: @events
   end
 
+  # GET /events/upcoming
+  def upcoming
+    today = Time.now.beginning_of_day
+    future_date = today + 2.years
+    range = today..future_date
+    @events = Event.where(start: range)
+  
+    render json: @events, include: [:user]
+  end
+
   # GET /events/1
   def show
     render json: @event
-  end
-
-    # GET /events/upcoming
-  def upcoming
-    today = Time.today.beginning_of_day
-    @events = Event.where('start > ?', today)
-  
-    render json: @events
   end
 
   # POST /events

--- a/apps/api/app/models/event.rb
+++ b/apps/api/app/models/event.rb
@@ -17,6 +17,10 @@
 #
 #  index_events_on_user_id  (user_id)
 #
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
 class Event < ApplicationRecord
   belongs_to :user
 end

--- a/apps/api/config/routes.rb
+++ b/apps/api/config/routes.rb
@@ -1,5 +1,9 @@
 Rails.application.routes.draw do
-  resources :events
+  resources :events do
+    collection do
+      get 'upcoming', to: 'events#upcoming'
+    end
+  end
   resources :users
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/apps/api/db/migrate/20221209002741_add_association_from_event_to_user.rb
+++ b/apps/api/db/migrate/20221209002741_add_association_from_event_to_user.rb
@@ -1,5 +1,5 @@
 class AddAssociationFromEventToUser < ActiveRecord::Migration[7.0]
   def change
-    add_foreign_key :events, users
+    add_foreign_key :events, :users
   end
 end

--- a/apps/api/db/schema.rb
+++ b/apps/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_09_000750) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_09_002741) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -35,4 +35,5 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_09_000750) do
     t.boolean "is_admin"
   end
 
+  add_foreign_key "events", "users"
 end

--- a/apps/api/db/seeds.rb
+++ b/apps/api/db/seeds.rb
@@ -5,3 +5,60 @@
 #
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
+require "time"
+
+Event.destroy_all
+User.destroy_all
+
+users = User.create!([{
+    name: "Daphne Sullivan",
+    email: "dsullivan@gmail.com",
+    is_admin: true
+},{
+    name: "Tanya McQuoid-Hunt",
+    email: "tanya@yahoo.com",
+    is_admin: false
+}, 
+{
+    name: "Ethan Spiller",
+    email: "espiller@startup.io",
+    is_admin: true
+},{
+    name: "Harper Spiller",
+    email: "harperspiller@eeocprotector.com",
+    is_admin: false
+}])
+
+users
+
+p "Created #{User.count} users"
+
+Event.create!([{
+    title: "Dog Park and Chill",
+    description: "Come meet new friends and hang out in prospect park! Both dogs and humans welcome.",
+    blurb: "Dogs and Humans welcome at this Prospect Park hang.",
+    start: Time.now.beginning_of_hour.prev_day,
+    end: Time.now.end_of_hour.prev_day,
+    address: "Prospect Park, Brooklyn, NY",
+    user_id: users[0].id
+}, 
+{
+    title: "Hike the Watkins Glen State Park Gorge Trail",
+    description: "Come meet new friends and hike the Watkins Glen State Park Gorge Trail.",
+    blurb: "Join us for a hike!",
+    start: Time.now.beginning_of_hour.next_month,
+    end: Time.now.end_of_hour.next_month,
+    address: "Watkins Glen, NY",
+    user_id: users[2].id
+},
+{
+    title: "Axe Throwing",
+    description: "Come meet new friends and throw some axes at Kick Axe Throwing!",
+    blurb: "Throw some axes! Meet new Friends",
+    start: Time.now.beginning_of_hour,
+    end: Time.now.end_of_hour,
+    address: "New York, NY",
+    user_id: users[3].id
+}]) 
+
+p "Created #{Event.count} events"

--- a/apps/api/test/fixtures/events.yml
+++ b/apps/api/test/fixtures/events.yml
@@ -17,6 +17,10 @@
 #
 #  index_events_on_user_id  (user_id)
 #
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
 
 one:
   title: MyString

--- a/apps/api/test/models/event_test.rb
+++ b/apps/api/test/models/event_test.rb
@@ -17,6 +17,10 @@
 #
 #  index_events_on_user_id  (user_id)
 #
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
 require "test_helper"
 
 class EventTest < ActiveSupport::TestCase

--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -1,4 +1,4 @@
-import { useGetAllEventsQuery } from "@our-scene/api-hooks";
+import { useGetAllEventsQuery, useGetUpcomingEventsQuery } from "@our-scene/api-hooks";
 import Head from "next/head";
 import ComingSoon from "../components/ComingSoon";
 import { useUserAuthContext } from "../components/contexts/UserAuthContextProvider";
@@ -14,15 +14,16 @@ export default function Home() {
     enabled: Boolean(session),
     refetchOnMount: "always",
   });
-  console.log(getUsersQuery)
+  // console.log(getQuery)
 
   const handleSignOut = () => {
     signOut();
   };
 
   // header, footer and body: coming soon component  
-  const getAllEventsQuery = useGetAllEventsQuery(session?.idToken, { enabled: Boolean(session?.idToken) })
-  console.log('Events: ', getAllEventsQuery)
+  // const getAllEventsQuery = useGetAllEventsQuery(session?.idToken, { enabled: Boolean(session?.idToken) })
+  const getUpcomingEventsQuery = useGetUpcomingEventsQuery(session?.idToken, { enabled: Boolean(session?.idToken) });
+  console.log('Upcoming Events: ', getUpcomingEventsQuery)
   // const queryClient = useQueryClient()
 
   return (

--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -21,7 +21,7 @@ export default function Home() {
   };
 
   // header, footer and body: coming soon component  
-  // const getAllEventsQuery = useGetAllEventsQuery(session?.idToken, { enabled: Boolean(session?.idToken) })
+  const getAllEventsQuery = useGetAllEventsQuery(session?.idToken, { enabled: Boolean(session?.idToken) })
   const getUpcomingEventsQuery = useGetUpcomingEventsQuery(session?.idToken, { enabled: Boolean(session?.idToken) });
   console.log('Upcoming Events: ', getUpcomingEventsQuery)
   // const queryClient = useQueryClient()

--- a/packages/api-hooks/resources/events/index.ts
+++ b/packages/api-hooks/resources/events/index.ts
@@ -1,10 +1,10 @@
 import axios from 'axios'
 import { useQuery, UseQueryOptions } from "@tanstack/react-query"
-import { GetAllEvents } from './types'
+import { GetAllEvents, GetUpcomingEvents } from './types'
 import { createAxiosClientWithAuth } from '../../lib/axios';
 
 const EVENTS_ROOT_PATH = '/events';
-
+const UPCOMING_EVENTS_ROOT_PATH = '/events/upcoming';
 
 const generateGetAllEventsWithAuth = (idToken: string) => {
   
@@ -20,3 +20,19 @@ export const useGetAllEventsQuery = (sessionIdToken: string, options: UseQueryOp
   const { path: queryKey, fn } = generateGetAllEventsWithAuth(sessionIdToken);
   return useQuery<GetAllEvents.Response>([queryKey], fn, options);
 }
+
+const generateGetUpcomingEvents = (idToken: string) => {
+  
+  const client = createAxiosClientWithAuth(idToken);
+  const fn = async () => {
+    const { data } = await client.get<GetUpcomingEvents.Response>(UPCOMING_EVENTS_ROOT_PATH);
+    return data;
+  };
+  return { path: UPCOMING_EVENTS_ROOT_PATH, fn };
+}
+
+export const useGetUpcomingEventsQuery = (sessionIdToken: string, options: UseQueryOptions<GetUpcomingEvents.Response> = {}) => {
+  const { path: queryKey, fn } = generateGetUpcomingEvents(sessionIdToken);
+  return useQuery<GetUpcomingEvents.Response>([queryKey], fn, options);
+}
+

--- a/packages/api-hooks/resources/events/types.ts
+++ b/packages/api-hooks/resources/events/types.ts
@@ -15,6 +15,14 @@ export declare namespace GetAllEvents {
   type Error = {} // TODO
 }
 
+export declare namespace GetUpcomingEvents {
+  type Request = {}
+
+  type Response = Event[]
+
+  type Error = {} // TODO
+}
+
 // export declare namespace GetWorkoutResponse {
 //   type Request = {
 //     pathParams: {


### PR DESCRIPTION
[OUR-35 ](https://linear.app/ourscene/issue/OUR-35/[api]-all-events-view-controller-method-andand-mode-validation)
- Added upcoming action to Events Controller that can successfully query events 2 years into the future
- Updated events routes in apps/api/config/routes.rb to access upcoming action on events controller at /events/upcoming
- Created Users and Events seed data that can be initialized with rails db:seed for testing purposes
- Generated UpcomingEvents query that fetches and caches upcoming events data in packages/api-hooks/resources/events/index.ts
- Tested the ability to successfully import and execute useGetUpcomingEventsQuery in apps/web/pages/index.tsx 

MISC
- Quick bug fix to AddAssociationFromEventToUser Migration, users was missing a colon which was causing the server to throw an error.